### PR TITLE
Make clear that rs.initiate() should not be run against multiple nodes

### DIFF
--- a/source/includes/steps-deploy-replica-set.yaml
+++ b/source/includes/steps-deploy-replica-set.yaml
@@ -51,7 +51,7 @@ title:
 stepnum: 3
 ref: initiate-rs
 pre: |
-  Use :method:`rs.initiate()` on the replica set member:
+  Use :method:`rs.initiate()` on one and only one of the replica set members:
 action:
   language: javascript
   code: |


### PR DESCRIPTION
Users have always been confused about rs.initiate() and have been known to run it against each node of a replica set. When they then go to rs.add() the other members to one node, sad things happen. These sad things are much sadder in 3.2, so we should do everything we can to help them avoid this. See https://jira.mongodb.org/browse/SERVER-22287 for more about the 3.2 sad things.